### PR TITLE
Update to make compatible with remarkable 2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 var hljs = require('highlight.js');
 var utils = require('handlebars-utils');
-var Remarkable = require('remarkable');
+var { Remarkable } = require('remarkable');
+var linkify = require('remarkable/linkify').linkify;
 var defaults = { html: true, breaks: true, highlight: highlight };
 
 module.exports = function(config) {
@@ -30,7 +31,16 @@ module.exports = function(config) {
       opts.langPrefix = opts.lang;
     }
 
-    var md = new Remarkable(opts);
+    var md;
+
+    if (opts.hasOwnProperty('linkify')) {
+      var useLinkify = opts.linkify ? opts.linkify : false;
+      delete opts.linkify;
+      md = (useLinkify) ? new Remarkable(opts).use(linkify) : new Remarkable(opts);
+    } else {
+      md = new Remarkable(opts);
+    }
+
     var val = utils.value(str, ctx, options);
     return md.render(val);
   }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var hljs = require('highlight.js');
 var utils = require('handlebars-utils');
-var { Remarkable } = require('remarkable');
+var Remarkable = require('remarkable').Remarkable;
 var linkify = require('remarkable/linkify').linkify;
 var defaults = { html: true, breaks: true, highlight: highlight };
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "handlebars-utils": "^1.0.2",
     "highlight.js": "^9.12.0",
-    "remarkable": "^1.7.1"
+    "remarkable": "^2.0.0"
   },
   "devDependencies": {
     "gulp-format-md": "^1.0.0",


### PR DESCRIPTION
Since remarkable 2 requires linkify to work through a plugin, I updated helper-markdown to work with the plugin. I opted to remove the linkify property from the opts object to prevent warnings from appearing. Issue here: https://github.com/helpers/helper-markdown/issues/11